### PR TITLE
Fix toast listener leak

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix `useToast` effect to avoid re-registering listeners on every render

## Testing
- `npm run lint` *(fails: 3 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_683f3de3709c832f93a26e6679a76b81