### PR TITLE
Fix toast viewport top positioning

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[9999] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[9999] flex max-h-screen w-full flex-col-reverse p-4 md:max-w-[420px]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- keep toast notifications at the top of all viewports

## Testing
- `bun test` *(fails: no matching test files)*

------
https://chatgpt.com/codex/tasks/task_e_6864583cc810832f84065ead0d0ac015